### PR TITLE
Fix PATH variable  update

### DIFF
--- a/recipes-support/snapd/snapd_2.25.bb
+++ b/recipes-support/snapd/snapd_2.25.bb
@@ -103,7 +103,7 @@ do_install_append() {
 	install -m 0755 ${B}/build/snap ${D}${bindir}
 	install -m 0755 ${B}/build/snapctl ${D}${bindir}
 
-	echo "PATH=$PATH:/snap/bin" > ${D}${sysconfdir}/profile.d/20-snap.sh
+	echo "PATH=\$PATH:/snap/bin" > ${D}${sysconfdir}/profile.d/20-snap.sh
 }
 
 RDEPENDS_${PN} += "squashfs-tools"


### PR DESCRIPTION
PATH variable on target image is getting build environment PATH variable
contents, escaping the special character will not expand the PATH variable.

closes https://github.intel.com/quadra-creek/meta-quadra-creek/issues/8