### PR TITLE
snapd: fixup the rule for building static snapd binaries, disable shared runtime on x86

### DIFF
--- a/recipes-support/snapd/snapd_2.30.bb
+++ b/recipes-support/snapd/snapd_2.30.bb
@@ -50,6 +50,11 @@ EXTRA_OECONF += "			\
 
 inherit systemd autotools pkgconfig go
 
+# disable shared runtime for x86
+# https://forum.snapcraft.io/t/yocto-rocko-core-snap-panic/3261
+# GO_DYNLINK is set with arch overrides in goarch.bbclass
+GO_DYNLINK_x86 = ""
+
 # Our tools build with autotools are inside the cmd subdirectory
 # and we need to tell the autotools class to look in there.
 AUTOTOOLS_SCRIPT_PATH = "${S}/cmd"

--- a/recipes-support/snapd/snapd_2.30.bb
+++ b/recipes-support/snapd/snapd_2.30.bb
@@ -71,10 +71,11 @@ do_configure() {
 do_compile() {
 	go_do_compile
 	# these *must* be built statically
-	${GO} install -v \
-		-ldflags="${GO_RPATH} -extldflags '${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS} ${GO_RPATH_LINK} ${LDFLAGS} -static'" \
-		${GO_IMPORT}/cmd/snap-update-ns \
-		${GO_IMPORT}/cmd/snap-exec
+	for prog in ${STATIC_GO_INSTALL}; do
+		${GO} install -v \
+		        -ldflags="${GO_RPATH} -extldflags '${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS} ${GO_RPATH_LINK} ${LDFLAGS} -static'" \
+		        $prog
+	done
 
   # build the rest
   autotools_do_compile


### PR DESCRIPTION
Previous commits introduced STATIC_GO_INSTALL variable that collects the
programs that are part of snapd suite and need to be built statically. Update
the compile recipe to use that variable instead of hardcoded list.