### PR TITLE
snapd: update to new upstream release 2.31

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ EOF
 ```
 
 The `snap-confine` tool assumes that the home directory of `root` is `/root`.
-Make sure we don not break this assumption, otherwise snaps mount namespace
+Make sure we do not break this assumption, otherwise snaps mount namespace
 setup will fail early in the process. To use `/root', set `ROOT_HOME` like
 this:`
 

--- a/recipes-support/snapd/snapd_2.31.bb
+++ b/recipes-support/snapd/snapd_2.31.bb
@@ -7,8 +7,8 @@ SRC_URI = "									\
 	https://${GO_IMPORT}/releases/download/${PV}/snapd_${PV}.vendor.tar.xz	\
 "
 
-SRC_URI[md5sum] = "4271c51bb2f0619f9e29d5b438a22196"
-SRC_URI[sha256sum] = "16bf669bfb13eda5a4b3a36787696e630102de5b891ed37aeb7caf42ec508f4d"
+SRC_URI[md5sum] = "3df61f6536284d8933b1d17809a9894b"
+SRC_URI[sha256sum] = "94ed98d0031c8b2ad01f01c0e8bc8814333e52e7442b1022b68e8c5dbe07b840"
 
 GO_IMPORT = "github.com/snapcore/snapd"
 
@@ -37,6 +37,7 @@ DEPENDS += "			\
 RDEPENDS_${PN} += "		\
 	ca-certificates		\
 	kernel-module-squashfs	\
+	bash \
 "
 
 S = "${WORKDIR}/${PN}-${PV}"


### PR DESCRIPTION
Update to 2.31. 

`bash` is a new dependenc for `snap-mgmt` tool.