### PR TITLE
updates: snapd 2.32.2, libseccomp 2.3.3

### DIFF
--- a/recipes-support/libseccomp/libseccomp_2.3.3.bb
+++ b/recipes-support/libseccomp/libseccomp_2.3.3.bb
@@ -7,10 +7,8 @@ SECTION = "security"
 LICENSE = "LGPL-2.1"
 LIC_FILES_CHKSUM = "file://LICENSE;beginline=0;endline=1;md5=8eac08d22113880357ceb8e7c37f989f"
 
-# v2.3.2 release commit
-SRCREV = "2331d104bc0cbde5f6c54e504a038e52bfe8e12d"
-
-PV = "2.3.2+git${SRCPV}"
+# v2.3.3 release commit
+SRCREV = "74b190e1aa05f07da0c61fb9a30dbc9c18ce2c9d"
 
 SRC_URI = "git://github.com/seccomp/libseccomp.git;branch=release-2.3 \
            file://run-ptest \

--- a/recipes-support/snapd/snapd_2.32.2.bb
+++ b/recipes-support/snapd/snapd_2.32.2.bb
@@ -7,8 +7,8 @@ SRC_URI = "									\
 	https://${GO_IMPORT}/releases/download/${PV}/snapd_${PV}.vendor.tar.xz	\
 "
 
-SRC_URI[md5sum] = "3df61f6536284d8933b1d17809a9894b"
-SRC_URI[sha256sum] = "94ed98d0031c8b2ad01f01c0e8bc8814333e52e7442b1022b68e8c5dbe07b840"
+SRC_URI[md5sum] = "cdb72d9110cbbc0a3a7a3896d4a100cb"
+SRC_URI[sha256sum] = "21e27119da2a04d670860c9edbb0d28d190c4ff67fa1a1dc517e0278fe95f2b5"
 
 GO_IMPORT = "github.com/snapcore/snapd"
 
@@ -98,6 +98,7 @@ do_install() {
 	install -d ${D}/var/lib/snapd/environment
 	install -d ${D}/var/snap
 	install -d ${D}${sysconfdir}/profile.d
+  install -d ${D}${systemd_unitdir}/system-generators
 
 	oe_runmake -C ${B} install DESTDIR=${D}
 	oe_runmake -C ${S}/data/systemd install \
@@ -107,6 +108,8 @@ do_install() {
 		SYSTEMDSYSTEMUNITDIR=${systemd_system_unitdir} \
 		SNAP_MOUNT_DIR=/snap \
 		SNAPD_ENVIRONMENT_FILE=${sysconfdir}/default/snapd
+
+  mv ${D}${libdir}/snapd/snapd-generator ${D}${systemd_unitdir}/system-generators/
 
 	install -m 0755 ${B}/${GO_BUILD_BINDIR}/snapd ${D}${libdir}/snapd/
 	install -m 0755 ${B}/${GO_BUILD_BINDIR}/snap-exec ${D}${libdir}/snapd/
@@ -119,11 +122,12 @@ do_install() {
 }
 
 RDEPENDS_${PN} += "squashfs-tools"
-FILES_${PN} += "			\
-	${systemd_unitdir}/system/	\
-	/var/lib/snapd			\
-	/var/snap			\
-	${baselib}/udev/snappy-app-dev	\
+FILES_${PN} += "                        \
+	${systemd_unitdir}/system/            \
+	${systemd_unitdir}/system-generators/	\
+	/var/lib/snapd                        \
+	/var/snap                             \
+	${baselib}/udev/snappy-app-dev        \
 "
 
 # ERROR: snapd-2.23.5-r0 do_package_qa: QA Issue: No GNU_HASH in the elf binary:


### PR DESCRIPTION
Merge libseccomp changes from https://git.yoctoproject.org/cgit/cgit.cgi/meta-security/tree/recipes-security/libseccomp

Bumped snapd release to 2.32.2. `snapd` now ships a systemd generator, however it ends up in the wrong directory during `make install`. The recipe moves it back to the proper location.