### PR TITLE
One more fix for Yocto 2.6.x Thud support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ required for Snappy:
  * snapd
  * libseccomp
 
-The layer currently supports Yocto 2.4.x Rocko release.
+The layer currently supports Yocto 2.6.x Thud release.
 
 Aside from OE-core, `meta-snappy` also depends on `meta-openembedded` and
 `meta-filesystems`.

--- a/recipes-support/snapd/snapd_2.37.4.bb
+++ b/recipes-support/snapd/snapd_2.37.4.bb
@@ -27,7 +27,7 @@ STATIC_GO_INSTALL = " \
 GO_INSTALL = "${SHARED_GO_INSTALL}"
 
 DEPENDS += "			\
-	go-cross-${TARGET_ARCH}	\
+	go-cross-${TUNE_PKGARCH}	\
 	glib-2.0		\
 	udev			\
 	xfsprogs		\


### PR DESCRIPTION
The Go cross-compiler is now named go-cross-${TUNE_PKGARCH} in Yocto 2.6.x.